### PR TITLE
command line params to launch directly into mission

### DIFF
--- a/cmd/mission.go
+++ b/cmd/mission.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/pixelmek-3d/pixelmek-3d/game"
+	"github.com/pixelmek-3d/pixelmek-3d/game/model"
+	"github.com/spf13/cobra"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	rootCmd.AddCommand(missionCmd)
+
+	missionCmd.Flags().StringVarP(&missionFile, "file", "p", "", "mission file")
+	missionCmd.MarkFlagRequired("file")
+
+	missionCmd.Flags().StringVar(&mechFile, "mech", "", "mech file")
+}
+
+var (
+	missionFile string
+	mechFile    string
+	missionCmd  = &cobra.Command{
+		Use:   "mission",
+		Short: "Load directly into a mission",
+		Run: func(cmd *cobra.Command, args []string) {
+			g := game.NewGame()
+
+			// load the mission path specified
+			_, err := g.LoadMission(missionFile)
+			if err != nil {
+				log.Error("Error loading mission file: ", missionFile)
+				log.Error(err)
+
+				missionList, _ := model.ListMissionFilenames()
+				if len(missionList) > 0 {
+					log.Error("Mission files available:\n", strings.Join(missionList[:], "\n"))
+				}
+				os.Exit(1)
+			}
+
+			// load the unit file specified, or random unit if not provided
+			if len(mechFile) == 0 {
+				g.SetPlayerUnit(g.RandomUnit(model.MechResourceType))
+			} else {
+				unit := g.LoadUnit(model.MechResourceType, mechFile)
+				if unit == nil {
+					log.Error("Error loading mech file: ", mechFile)
+					unitList := make([]string, 0, len(g.Resources().Mechs))
+					for k := range g.Resources().Mechs {
+						unitList = append(unitList, k)
+					}
+					sort.Strings(unitList)
+					if len(unitList) > 0 {
+						log.Error("Mech files available:\n", strings.Join(unitList[:], "\n"))
+					}
+					os.Exit(1)
+				} else {
+					g.SetPlayerUnit(unit)
+				}
+			}
+
+			// initialize the menu system
+			g.SetScene(game.NewMenuScene(g))
+
+			// jump straight to the game scene
+			g.SetScene(game.NewGameScene(g))
+
+			g.Run()
+		},
+	}
+)

--- a/game/game.go
+++ b/game/game.go
@@ -204,6 +204,23 @@ func NewGame() *Game {
 	return g
 }
 
+func (g *Game) Resources() *model.ModelResources {
+	return g.resources
+}
+
+func (g *Game) SetScene(scene Scene) {
+	g.scene = scene
+}
+
+func (g *Game) LoadMission(missionFile string) (*model.Mission, error) {
+	mission, err := model.LoadMission(missionFile)
+	if err != nil {
+		return nil, err
+	}
+	g.mission = mission
+	return mission, err
+}
+
 func (g *Game) initMission() {
 	if g.mission == nil {
 		panic("g.mission must be set before initMission!")
@@ -1315,7 +1332,20 @@ func (g *Game) updateWeaponCooldowns(unit model.Unit) {
 	}
 }
 
-func (g *Game) randomUnit(unitResourceType string) model.Unit {
+func (g *Game) LoadUnit(unitResourceType, unitFile string) model.Unit {
+	// TODO: make it useful for unit of any unit type
+	switch unitResourceType {
+	case model.MechResourceType:
+		if resource, ok := g.resources.Mechs[unitFile]; ok {
+			return g.createModelMechFromResource(resource)
+		}
+	default:
+		panic(fmt.Errorf("currently unable to handle load model.Unit for resource type %v", unitResourceType))
+	}
+	return nil
+}
+
+func (g *Game) RandomUnit(unitResourceType string) model.Unit {
 	// TODO: make it useful for random unit of any unit type, or within some tonnage range
 	switch unitResourceType {
 	case model.MechResourceType:

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -189,7 +189,7 @@ func ListMissionFilenames() ([]string, error) {
 
 	for _, f := range missionFiles {
 		if f.IsDir() {
-			// only folders with unit type name expected
+			// only folder with mission files expected
 			continue
 		}
 

--- a/game/scene_instant_action.go
+++ b/game/scene_instant_action.go
@@ -79,7 +79,7 @@ func (s *InstantActionScene) next() {
 		// launch mission scene
 		if g.player == nil {
 			// pick player unit at random
-			g.SetPlayerUnit(g.randomUnit(model.MechResourceType))
+			g.SetPlayerUnit(g.RandomUnit(model.MechResourceType))
 		}
 
 		g.scene = NewGameScene(g)


### PR DESCRIPTION
Developer convenience option to start the game directly into a mission without going through menus.

Example usage:

```bash
./pixelmek-3d mission --file trial_day.yaml --mech timber_wolf_prime.yaml
```
