### PR TITLE
convert map sprites height to meters instead of scale

### DIFF
--- a/game/clutter.go
+++ b/game/clutter.go
@@ -88,6 +88,7 @@ func (c *ClutterHandler) Update(g *Game, forceUpdate bool) {
 				}
 
 				clutterImg := g.tex.texMap[clutter.Image]
+				clutterScale := clutter.Height / model.METERS_PER_UNIT
 				cSprite := render.NewSprite(
 					model.BasicVisualEntity(
 						float64(x)+c.rng.Float64(),
@@ -95,7 +96,8 @@ func (c *ClutterHandler) Update(g *Game, forceUpdate bool) {
 						0,
 						raycaster.AnchorBottom,
 					),
-					clutter.Scale, clutterImg,
+					clutterScale,
+					clutterImg,
 				)
 
 				// store clutter sprites and which coordinate position id they are in

--- a/game/content.go
+++ b/game/content.go
@@ -188,10 +188,7 @@ func (g *Game) loadContent() {
 			continue
 		}
 
-		if s.Scale == 0.0 {
-			// default unset scale to 1.0
-			s.Scale = 1.0
-		}
+		scale := s.Height / model.METERS_PER_UNIT
 
 		var spriteImg *ebiten.Image
 		if eImg, ok := g.tex.texMap[s.Image]; ok {
@@ -207,7 +204,7 @@ func (g *Game) loadContent() {
 			x, y, z := position[0], position[1], s.ZPosition
 
 			collisionRadius, collisionHeight := convertOffsetFromPx(
-				s.CollisionPxRadius, s.CollisionPxHeight, sWidth, sHeight, s.Scale,
+				s.CollisionPxRadius, s.CollisionPxHeight, sWidth, sHeight, scale,
 			)
 
 			hitPoints := math.MaxFloat64
@@ -217,7 +214,8 @@ func (g *Game) loadContent() {
 
 			sprite := render.NewSprite(
 				model.BasicCollisionEntity(x, y, z, s.Anchor.SpriteAnchor, collisionRadius, collisionHeight, hitPoints),
-				s.Scale, spriteImg,
+				scale,
+				spriteImg,
 			)
 
 			g.sprites.addMapSprite(sprite)

--- a/game/model/map.go
+++ b/game/model/map.go
@@ -66,7 +66,7 @@ type MapClutter struct {
 	Image          string  `yaml:"image"`
 	FloorPathMatch *RegExp `yaml:"floorPathMatch"`
 	Frequency      float64 `yaml:"frequency"`
-	Scale          float64 `yaml:"scale"`
+	Height         float64 `yaml:"height"`
 }
 
 type SpriteAnchor struct {
@@ -115,7 +115,7 @@ type MapSprite struct {
 	CollisionPxRadius float64      `yaml:"collisionRadius"`
 	CollisionPxHeight float64      `yaml:"collisionHeight"`
 	HitPoints         float64      `yaml:"hitPoints"`
-	Scale             float64      `default:"1.0" yaml:"scale,omitempty"`
+	Height            float64      `yaml:"height"`
 	Anchor            SpriteAnchor `yaml:"anchor"`
 	Stamp             string       `yaml:"stamp"`
 }
@@ -126,7 +126,7 @@ type MapSpriteFill struct {
 	CollisionPxRadius float64    `yaml:"collisionRadius"`
 	CollisionPxHeight float64    `yaml:"collisionHeight"`
 	HitPoints         float64    `yaml:"hitPoints"`
-	ScaleRange        [2]float64 `yaml:"scaleRange"`
+	HeightRange       [2]float64 `yaml:"heightRange"`
 	Rect              [2][2]int  `yaml:"rect"`
 }
 
@@ -274,10 +274,11 @@ func (m *Map) generateFillerSprites() error {
 
 		for i := 0; i < fill.Quantity; i++ {
 			fX, fY := RandFloat64In(x0, x1, rng), RandFloat64In(y0, y1, rng)
-			scale := 1.0
-			if len(fill.ScaleRange) == 2 {
-				// generate random scale value within scale range
-				scale = RandFloat64In(fill.ScaleRange[0], fill.ScaleRange[1], rng)
+
+			var height float64
+			if len(fill.HeightRange) == 2 {
+				// generate random height value within height range
+				height = RandFloat64In(fill.HeightRange[0], fill.HeightRange[1], rng)
 			}
 
 			mapSprite := MapSprite{
@@ -286,7 +287,7 @@ func (m *Map) generateFillerSprites() error {
 				CollisionPxRadius: fill.CollisionPxRadius,
 				CollisionPxHeight: fill.CollisionPxHeight,
 				HitPoints:         fill.HitPoints,
-				Scale:             scale,
+				Height:            height,
 			}
 			nSprites = append(nSprites, mapSprite)
 		}
@@ -324,7 +325,7 @@ func (m *Map) generateSpritesFromStamps() error {
 							CollisionPxRadius: stampSprite.CollisionPxRadius,
 							CollisionPxHeight: stampSprite.CollisionPxHeight,
 							HitPoints:         stampSprite.HitPoints,
-							Scale:             stampSprite.Scale,
+							Height:            stampSprite.Height,
 						}
 						nSprites = append(nSprites, mapSprite)
 					}

--- a/game/resources/maps/debug_land.yaml
+++ b/game/resources/maps/debug_land.yaml
@@ -43,18 +43,29 @@ clutter:
   floorPathMatch: "desert"
   frequency: 0.3
 spriteFill:
-- image: "shrubbery/tree_0.png"
+- sprite: "tree_0"
   heightRange: [4, 16]
-  collisionRadius: 80
-  collisionHeight: 220
-  hitPoints: 0.1
   quantity: 100
   rect: [[42, 25], [64, 55]]
-spriteStamps: []
+spriteStamps:
+- # tree line
+  positions:
+    - [59, 59]
+    - [62, 62]
+  sprites:
+  - sprite: "tree_0"
+    height: 10
+    positions:
+    - [0, 0]
+    - [0.5, 0]
+    - [1.0, 0]
+    - [1.5, 0]
+    - [2.0, 0]
 sprites:
-- image: "shrubbery/tree_0.png"
+- id: "tree_0"
+  image: "shrubbery/tree_0.png"
   height: 20
-  collisionRadius: 60
+  collisionRadius: 56
   collisionHeight: 190
   hitPoints: 0.1
   positions:

--- a/game/resources/maps/debug_land.yaml
+++ b/game/resources/maps/debug_land.yaml
@@ -37,11 +37,23 @@ generateLevels:
 flooring:
   default: "floors/desert_rough.png"
   pathing: []
-clutter: []
-spriteFill: []
+clutter:
+- image: "rocks/rock_0.png"
+  height: 1.0
+  floorPathMatch: "desert"
+  frequency: 0.3
+spriteFill:
+- image: "shrubbery/tree_0.png"
+  heightRange: [4, 16]
+  collisionRadius: 80
+  collisionHeight: 220
+  hitPoints: 0.1
+  quantity: 100
+  rect: [[42, 25], [64, 55]]
 spriteStamps: []
 sprites:
 - image: "shrubbery/tree_0.png"
+  height: 20
   collisionRadius: 60
   collisionHeight: 190
   hitPoints: 0.1

--- a/game/resources/maps/testing_grounds.yaml
+++ b/game/resources/maps/testing_grounds.yaml
@@ -77,32 +77,33 @@ flooring:
     - [[19, 15], [24, 1], [50, 1], [50, 50], [24, 50]]
 clutter:
 - image: "rocks/rock_0.png"
-  scale: 0.05
+  height: 1.0
   floorPathMatch: "grass"
   frequency: 0.3
 - image: "shrubbery/bush_0.png"
-  scale: 0.05
+  height: 1.0
   floorPathMatch: "grass"
   frequency: 0.5
 spriteFill:
 - image: "shrubbery/tree_1.png"
+  heightRange: [12, 20]
   collisionRadius: 80
   collisionHeight: 220
   hitPoints: 0.1
-  scaleRange: [0.6, 1.0]
   quantity: 100
   rect: [[42, 15], [64, 30]]
 - image: "shrubbery/tree_1.png"
+  heightRange: [8, 14]
   collisionRadius: 80
   collisionHeight: 220
   hitPoints: 0.1
-  scaleRange: [0.4, 0.7]
   quantity: 200
   rect: [[150, 150], [350, 350]]
 spriteStamps:
 - id: "tree line L2"
   sprites:
   - image: "shrubbery/tree_1.png"
+    height: 20
     collisionRadius: 80
     collisionHeight: 220
     hitPoints: 0.1
@@ -112,15 +113,16 @@ spriteStamps:
     - [1.5, 0]
     - [2.0, 0]
   - image: "shrubbery/tree_0.png"
+    height: 20
     collisionRadius: 60
     collisionHeight: 190
     hitPoints: 0.1
-    scale: 0.5
     positions:
     - [1.0, 0]
 - id: "forest circle R6"
   sprites:
   - image: "shrubbery/tree_1.png"
+    height: 20
     collisionRadius: 80
     collisionHeight: 220
     hitPoints: 0.1
@@ -149,6 +151,7 @@ spriteStamps:
     - [5.5, 4.6]
 sprites:
 - image: "shrubbery/tree_0.png"
+  height: 20
   collisionRadius: 60
   collisionHeight: 190
   hitPoints: 0.1
@@ -156,10 +159,12 @@ sprites:
   - [8.5, 24.5]
   - [10.5, 24.5]
 - stamp: "tree line L2"
+  height: 20
   positions:
   - [19.5, 25.5]
   - [20.5, 23.5]
 - stamp: "forest circle R6"
+  height: 20
   positions:
   - [21, 52]
   - [100, 52]

--- a/game/resources/maps/testing_grounds.yaml
+++ b/game/resources/maps/testing_grounds.yaml
@@ -85,47 +85,40 @@ clutter:
   floorPathMatch: "grass"
   frequency: 0.5
 spriteFill:
-- image: "shrubbery/tree_1.png"
+- sprite: "tree_1"
   heightRange: [12, 20]
-  collisionRadius: 80
-  collisionHeight: 220
-  hitPoints: 0.1
   quantity: 100
   rect: [[42, 15], [64, 30]]
-- image: "shrubbery/tree_1.png"
+- sprite: "tree_1"
   heightRange: [8, 14]
-  collisionRadius: 80
-  collisionHeight: 220
-  hitPoints: 0.1
   quantity: 200
   rect: [[150, 150], [350, 350]]
 spriteStamps:
-- id: "tree line L2"
+- # lines of trees
+  positions:
+  - [19.5, 25.5]
+  - [20.5, 23.5]
   sprites:
-  - image: "shrubbery/tree_1.png"
+  - sprite: "tree_1"
     height: 20
-    collisionRadius: 80
-    collisionHeight: 220
-    hitPoints: 0.1
     positions:
     - [0, 0]
     - [0.5, 0]
     - [1.5, 0]
     - [2.0, 0]
-  - image: "shrubbery/tree_0.png"
+  - sprite: "tree_0"
     height: 20
-    collisionRadius: 60
-    collisionHeight: 190
-    hitPoints: 0.1
     positions:
     - [1.0, 0]
-- id: "forest circle R6"
+- # forest circles
+  positions:
+  - [21, 52]
+  - [100, 52]
+  - [21, 100]
+  - [100, 125]
   sprites:
-  - image: "shrubbery/tree_1.png"
+  - sprite: "tree_1"
     height: 20
-    collisionRadius: 80
-    collisionHeight: 220
-    hitPoints: 0.1
     positions:
     - [0.1, 3.0]
     - [0.7, 4.2]
@@ -150,23 +143,19 @@ spriteStamps:
     - [5.4, 2.5]
     - [5.5, 4.6]
 sprites:
-- image: "shrubbery/tree_0.png"
+- id: "tree_0"
+  image: "shrubbery/tree_0.png"
   height: 20
-  collisionRadius: 60
+  collisionRadius: 56
   collisionHeight: 190
   hitPoints: 0.1
   positions:
   - [8.5, 24.5]
   - [10.5, 24.5]
-- stamp: "tree line L2"
+- id: "tree_1"
+  image: "shrubbery/tree_1.png"
   height: 20
-  positions:
-  - [19.5, 25.5]
-  - [20.5, 23.5]
-- stamp: "forest circle R6"
-  height: 20
-  positions:
-  - [21, 52]
-  - [100, 52]
-  - [21, 100]
-  - [100, 125]
+  collisionRadius: 60
+  collisionHeight: 190
+  hitPoints: 0.1
+  positions: []


### PR DESCRIPTION
- use meters instead of relative cell unit scale for sprite
  sizes defined in maps