### PR TITLE
Set mission initial player and unit powered status

### DIFF
--- a/game/ai.go
+++ b/game/ai.go
@@ -491,7 +491,11 @@ func (h *AIHandler) isUnitPowerConditionMet(u model.Unit) bool {
 		// TODO: check if the mission nav point has been visited by player yet
 	}
 	if len(pConditions.MissionUnitDestroyed) > 0 {
-		// TODO: check if the referenced unit id is destroyed
+		// check if the referenced unit id is destroyed
+		mUnit := h.g.getSpriteUnitByID(pConditions.MissionUnitDestroyed)
+		if mUnit == nil || mUnit.IsDestroyed() {
+			return true
+		}
 	}
 	if pConditions.PlayerDistance > 0 {
 		// TODO: calculate distance from player, return true if <= distance

--- a/game/ai.go
+++ b/game/ai.go
@@ -450,8 +450,10 @@ func (h *AIHandler) Update() {
 
 		powerStatus := a.u.Powered()
 		if powerStatus == model.POWER_OFF_MANUAL {
-			// use mission unit power conditions to define when to initiate power on
-			a.u.SetPowered(model.POWER_ON)
+			// use mission unit power on conditions to decide when to initiate power on
+			if h.isUnitPowerConditionMet(a.u) {
+				a.u.SetPowered(model.POWER_ON)
+			}
 			continue
 		} else if powerStatus != model.POWER_ON {
 			continue
@@ -470,23 +472,29 @@ func (h *AIHandler) Update() {
 	}
 }
 
+// return true if any one of the set power conditions are met
 func (h *AIHandler) isUnitPowerConditionMet(u model.Unit) bool {
-	// return true if any one of the set power conditions are met
 	pConditions := u.PowerConditions()
 	if pConditions == nil {
 		return true
 	}
-	if pConditions.MissionTimeElapsed > 0 {
-		// TODO: mission.elapsedTime
+	if h.g.mission == nil {
+		return false
 	}
-	if pConditions.PlayerDistance > 0 {
-		// TODO: calculate distance from player, return true if <= distance
+	if pConditions.MissionTimeElapsed > 0 {
+		// check if the mission timer has met the elapsed time condition
+		if int(h.g.mission.TimerSeconds()) >= pConditions.MissionTimeElapsed {
+			return true
+		}
 	}
 	if len(pConditions.NavPointVisited) > 0 {
-		// TODO: check if the nav point is visited by player yet
+		// TODO: check if the mission nav point has been visited by player yet
 	}
 	if len(pConditions.MissionUnitDestroyed) > 0 {
 		// TODO: check if the referenced unit id is destroyed
+	}
+	if pConditions.PlayerDistance > 0 {
+		// TODO: calculate distance from player, return true if <= distance
 	}
 	return false
 }

--- a/game/ai.go
+++ b/game/ai.go
@@ -506,7 +506,13 @@ func (h *AIHandler) isUnitPowerConditionMet(u model.Unit) bool {
 		}
 	}
 	if pConditions.PlayerDistance > 0 {
-		// TODO: calculate distance from player, return true if <= distance
+		// calculate distance (in meters) from player, return true if <= distance
+		uPos := u.Pos()
+		pPos := h.g.player.Pos()
+		pDist := geom.Distance(uPos.X, uPos.Y, pPos.X, pPos.Y) * model.METERS_PER_UNIT
+		if pDist <= float64(pConditions.PlayerDistance) {
+			return true
+		}
 	}
 	return false
 }

--- a/game/ai.go
+++ b/game/ai.go
@@ -488,7 +488,15 @@ func (h *AIHandler) isUnitPowerConditionMet(u model.Unit) bool {
 		}
 	}
 	if len(pConditions.NavPointVisited) > 0 {
-		// TODO: check if the mission nav point has been visited by player yet
+		// check if the mission nav point has been visited by player yet
+		for _, nav := range h.g.mission.NavPoints {
+			if nav.Name == pConditions.NavPointVisited {
+				if nav.Visited() {
+					return true
+				}
+				break
+			}
+		}
 	}
 	if len(pConditions.MissionUnitDestroyed) > 0 {
 		// check if the referenced unit id is destroyed

--- a/game/ai.go
+++ b/game/ai.go
@@ -450,6 +450,7 @@ func (h *AIHandler) Update() {
 
 		powerStatus := a.u.Powered()
 		if powerStatus == model.POWER_OFF_MANUAL {
+			// use mission unit power conditions to define when to initiate power on
 			a.u.SetPowered(model.POWER_ON)
 			continue
 		} else if powerStatus != model.POWER_ON {
@@ -467,6 +468,27 @@ func (h *AIHandler) Update() {
 			log.Error(err)
 		}
 	}
+}
+
+func (h *AIHandler) isUnitPowerConditionMet(u model.Unit) bool {
+	// return true if any one of the set power conditions are met
+	pConditions := u.PowerConditions()
+	if pConditions == nil {
+		return true
+	}
+	if pConditions.MissionTimeElapsed > 0 {
+		// TODO: mission.elapsedTime
+	}
+	if pConditions.PlayerDistance > 0 {
+		// TODO: calculate distance from player, return true if <= distance
+	}
+	if len(pConditions.NavPointVisited) > 0 {
+		// TODO: check if the nav point is visited by player yet
+	}
+	if len(pConditions.MissionUnitDestroyed) > 0 {
+		// TODO: check if the referenced unit id is destroyed
+	}
+	return false
 }
 
 func NewAIGunnery(u model.Unit) *AIGunnery {

--- a/game/ai.go
+++ b/game/ai.go
@@ -444,7 +444,15 @@ func (h *AIHandler) Update() {
 	// only update AI whose initiative slot is next
 	turnAI := h.initiative.Next()
 	for _, a := range turnAI {
-		if a.u.IsDestroyed() || a.u.Powered() != model.POWER_ON {
+		if a.u.IsDestroyed() {
+			continue
+		}
+
+		powerStatus := a.u.Powered()
+		if powerStatus == model.POWER_OFF_MANUAL {
+			a.u.SetPowered(model.POWER_ON)
+			continue
+		} else if powerStatus != model.POWER_ON {
 			continue
 		}
 

--- a/game/ai_combat.go
+++ b/game/ai_combat.go
@@ -29,9 +29,12 @@ func (a *AIBehavior) HasTarget() func([]bt.Node) (bt.Status, error) {
 
 			// log.Debugf("[%s] hasTarget == %s", a.u.ID(), t.ID())
 			if a.u.Target() != t {
+				if !a.g.IsTargetableAtDistance(a.u, t, p.distance) {
+					// make sure new target is targetable, while allowing for current target to remain even if it has shutdown
+					continue
+				}
 				// reset AI settings for previous targets
 				a.gunnery.Reset()
-
 				a.u.SetTarget(t)
 			}
 

--- a/game/common/strings.go
+++ b/game/common/strings.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // FloatDisplayString returns a displayable string value of a float with any trailing zeros/periods removed.
@@ -11,4 +12,14 @@ func FloatDisplayString(f float64) string {
 	dispStr = strings.TrimRight(dispStr, "0")
 	dispStr = strings.TrimRight(dispStr, ".")
 	return dispStr
+}
+
+// DurationDisplayString returns a displayable string value of a duration in hours:minutes:seconds (e.g. `32:09:14“)
+func DurationDisplayString(d time.Duration) string {
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+
+	str := fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+	return str
 }

--- a/game/content.go
+++ b/game/content.go
@@ -194,6 +194,8 @@ func createMissionUnitModel[T model.MissionUnitModels](g *Game, unit model.Missi
 	u.SetTurretAngle(rHeading)
 	u.SetTargetTurretAngle(rHeading)
 
+	u.SetPowerConditions(unit.PowerConditions)
+
 	u.SetGuardUnit(unit.GuardUnit)
 	if len(unit.GuardArea.Position) == 2 && unit.GuardArea.Radius >= 0 &&
 		unit.GuardArea.Position[0] > 0 && unit.GuardArea.Position[1] > 0 {

--- a/game/game.go
+++ b/game/game.go
@@ -613,8 +613,8 @@ func (g *Game) targetCycle(cycleType TargetCycleType) model.Entity {
 
 	for _, p := range pSprites {
 		s := p.sprite
-		if g.IsFriendly(g.player, s.Entity) {
-			// skip friendly units
+		if g.IsFriendly(g.player, s.Entity) || !g.IsTargetable(g.player, s.Unit()) {
+			// skip friendly and untargetable units
 			continue
 		}
 		targetables = append(targetables, s)
@@ -702,6 +702,27 @@ func (g *Game) IsFriendly(e1, e2 model.Entity) bool {
 		return e1.Team() < 0 && e2.Team() < 0
 	}
 	return e1.Team() == e2.Team()
+}
+
+// IsTargetable returns true if the source unit is able to target the target unit based on current distance and power conditions
+func (g *Game) IsTargetable(source, target model.Unit) bool {
+	if target == nil {
+		return false
+	}
+	sPos, tPos := source.Pos(), target.Pos()
+	tDist := geom.Distance(sPos.X, sPos.Y, tPos.X, tPos.Y)
+	return g.IsTargetableAtDistance(source, target, tDist)
+}
+
+// IsTargetableAtDistance returns true if the source unit is able to target the target unit based on given distance and power conditions
+func (g *Game) IsTargetableAtDistance(source, target model.Unit, distance float64) bool {
+	if target == nil || source.Powered() != model.POWER_ON {
+		return false
+	}
+	if target.Powered() != model.POWER_ON {
+		return distance <= 200/model.METERS_PER_UNIT
+	}
+	return distance <= 1000/model.METERS_PER_UNIT
 }
 
 func randFloat(min, max float64) float64 {

--- a/game/game.go
+++ b/game/game.go
@@ -232,6 +232,9 @@ func (g *Game) Run() {
 
 func (g *Game) Pause() {
 	g.paused = true
+	if g.mission != nil {
+		g.mission.TimerPause()
+	}
 	g.audio.PauseMusic()
 	g.audio.PauseSFX()
 }
@@ -239,6 +242,9 @@ func (g *Game) Pause() {
 func (g *Game) Resume() {
 	g.audio.ResumeMusic()
 	g.audio.ResumeSFX()
+	if g.mission != nil {
+		g.mission.TimerStart()
+	}
 	g.paused = false
 }
 

--- a/game/hud.go
+++ b/game/hud.go
@@ -758,7 +758,7 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 
 	for _, s := range sprites {
 		entity := s.Entity
-		unit := model.EntityUnit(entity)
+		unit := s.Unit()
 		if unit == nil {
 			continue
 		}
@@ -783,6 +783,10 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 			} else {
 				continue
 			}
+		}
+
+		if !g.IsTargetableAtDistance(g.player, unit, unitDistance) {
+			continue
 		}
 
 		// determine angle of unit relative from player heading

--- a/game/hud.go
+++ b/game/hud.go
@@ -133,7 +133,15 @@ func (g *Game) resetHUDElementScale() {
 	}
 }
 
-// drawHUD draws HUD elements on the screen
+// updateHUD updates HUD elements on the screen that need animated (tick-based, not framerate)
+func (g *Game) updateHUD() {
+	radar := g.GetHUDElement(HUD_RADAR).(*render.Radar)
+	if radar != nil {
+		radar.Update()
+	}
+}
+
+// drawHUD draws HUD elements on the screen (framerate-based, not tick)
 func (g *Game) drawHUD(screen *ebiten.Image) {
 	hudRect := g.uiRect()
 	marginX, marginY := hudRect.Dx()/50, hudRect.Dy()/50
@@ -696,12 +704,9 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 		rX, rY, rX+radarWidth, rY+radarHeight,
 	)
 
-	// find all units and nav points within range to draw as blips
+	// find all units and nav points within range to render on radar
 	maxDistanceMeters := radar.RadarRange()
 	maxDistanceUnits := maxDistanceMeters / model.METERS_PER_UNIT
-
-	radarBlips := make([]*render.RadarBlip, 0, 128)
-	rNavPoints := make([]*render.RadarNavPoint, 0, len(g.mission.NavPoints))
 
 	camPos := hudOpts.HudUnit.Pos()
 	camHeading := hudOpts.HudUnit.Heading()
@@ -711,7 +716,7 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 	camNav := g.player.NavPoint()
 
 	// discover nav points that are in range
-	navCount := 0
+	rNavPoints := make([]*render.RadarNavPoint, 0, len(g.mission.NavPoints))
 	for _, nav := range g.mission.NavPoints {
 		navPos := nav.Pos()
 		navLine := geom.Line{
@@ -737,11 +742,10 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 		}
 
 		rNavPoints = append(rNavPoints, rNav)
-		navCount++
 	}
 
-	// discover blips that are in range
-	blipCount := 0
+	// discover blips and pings that are in range
+	radarBlips := make([]*render.RadarBlip, 0, 64)
 
 	// only get sprites in proximity of radar range
 	pSprites := g.getProximityUnitSprites(camPos, maxDistanceUnits)
@@ -785,12 +789,23 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 			}
 		}
 
+		// determine angle of unit relative from player heading
+		relAngle := camHeading - unitLine.Angle()
+
 		if !g.IsTargetableAtDistance(g.player, unit, unitDistance) {
+			// the unit is not targetable, do not show it as a blip
+			if unit.Powered() == model.POWER_ON_IN_PROGRESS {
+				// however the unit is powering on, show as a ping
+				ping := &render.RadarPing{
+					Entity:   entity,
+					Angle:    relAngle,
+					Distance: unitDistance,
+				}
+				radar.AddRadarPing(ping)
+			}
 			continue
 		}
 
-		// determine angle of unit relative from player heading
-		relAngle := camHeading - unitLine.Angle()
 		// determine heading of unit relative from player heading
 		relHeading := camHeading - unit.Heading()
 		relTurretHeading := camHeading - unit.TurretAngle()
@@ -806,7 +821,6 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 		}
 
 		radarBlips = append(radarBlips, blip)
-		blipCount++
 	}
 
 	if g.debug && (camTarget != nil || debugCamTgt != nil) {
@@ -843,8 +857,8 @@ func (g *Game) drawRadar(hudOpts *render.DrawHudOptions) {
 		radar.ShowPosition(true)
 	}
 
-	radar.SetNavPoints(rNavPoints[:navCount])
-	radar.SetRadarBlips(radarBlips[:blipCount])
+	radar.SetNavPoints(rNavPoints)
+	radar.SetRadarBlips(radarBlips)
 
 	radar.Draw(radarBounds, hudOpts)
 }

--- a/game/input.go
+++ b/game/input.go
@@ -367,7 +367,6 @@ func (g *Game) handleInput() {
 			}
 		} else if !g.InProgress() {
 			// instantly leave game when it is over
-			g.paused = true
 			g.LeaveGame()
 		} else {
 			g.openMenu()

--- a/game/menu_debrief.go
+++ b/game/menu_debrief.go
@@ -9,7 +9,8 @@ import (
 
 type DebriefMenu struct {
 	*MenuModel
-	content *widget.Container
+	content      *widget.Container
+	tickUpdaters []tickUpdater
 }
 
 func createDebriefMenu(g *Game) *DebriefMenu {
@@ -48,6 +49,9 @@ func (m *DebriefMenu) initMenu() {
 }
 
 func (m *DebriefMenu) Update() {
+	for _, updater := range m.tickUpdaters {
+		updater.update()
+	}
 	m.ui.Update()
 }
 
@@ -151,5 +155,7 @@ func (m *DebriefMenu) loadDebriefing() {
 		playerUnit = g.player.Unit
 	}
 	unitCard := createUnitCard(g, res, playerUnit, UnitCardDebrief)
+	// TODO: if player unit is destroyed, do not use the "walking" animation
+	m.tickUpdaters = []tickUpdater{unitCard}
 	m.content.AddChild(unitCard)
 }

--- a/game/menu_launch.go
+++ b/game/menu_launch.go
@@ -9,7 +9,8 @@ import (
 
 type LaunchMenu struct {
 	*MenuModel
-	content *widget.Container
+	content      *widget.Container
+	tickUpdaters []tickUpdater
 }
 
 func createLaunchMenu(g *Game) *LaunchMenu {
@@ -47,6 +48,9 @@ func (m *LaunchMenu) initMenu() {
 }
 
 func (m *LaunchMenu) Update() {
+	for _, updater := range m.tickUpdaters {
+		updater.update()
+	}
 	m.ui.Update()
 }
 
@@ -156,5 +160,6 @@ func (m *LaunchMenu) loadBriefing(mission *model.Mission) {
 		playerUnit = g.player.Unit
 	}
 	unitCard := createUnitCard(g, res, playerUnit, UnitCardLaunch)
+	m.tickUpdaters = []tickUpdater{unitCard}
 	m.content.AddChild(unitCard)
 }

--- a/game/menu_mission.go
+++ b/game/menu_mission.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/widget"
@@ -46,8 +47,9 @@ const (
 
 type MissionCard struct {
 	*widget.Container
-	style          MissionCardStyle
-	objectivesText *widget.TextArea
+	style           MissionCardStyle
+	objectivesText  *widget.TextArea
+	elapsedTimeText *widget.Text
 }
 
 var missionImage *missionMapImage
@@ -341,8 +343,19 @@ func createMissionCard(g *Game, res *uiResources, mission *model.Mission, style 
 		cardContainer.AddChild(missionTitle)
 	}
 
-	var objectivesText *widget.TextArea
+	var elapsedTimeText *widget.Text
+	switch style {
+	case MissionCardGame, MissionCardDebrief:
+		elapsedTimeText = widget.NewText(widget.TextOpts.Text(missionElapsedTime(g), res.text.face, res.text.idleColor),
+			widget.TextOpts.WidgetOpts(widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Stretch: true,
+			})),
+			widget.TextOpts.Position(widget.TextPositionStart, widget.TextPositionCenter),
+		)
+		cardContainer.AddChild(elapsedTimeText)
+	}
 
+	var objectivesText *widget.TextArea
 	switch style {
 	case MissionCardSelect, MissionCardLaunch:
 		// mission map area text
@@ -399,18 +412,30 @@ func createMissionCard(g *Game, res *uiResources, mission *model.Mission, style 
 	}
 
 	missionCard := &MissionCard{
-		Container:      cardContainer,
-		style:          style,
-		objectivesText: objectivesText,
+		Container:       cardContainer,
+		style:           style,
+		objectivesText:  objectivesText,
+		elapsedTimeText: elapsedTimeText,
 	}
 
 	return missionCard
 }
 
+func missionElapsedTime(g *Game) string {
+	if g.mission == nil {
+		return ""
+	}
+	elapsedTime := time.Duration(g.mission.TimerSeconds() * float64(time.Second))
+	return fmt.Sprintf("Elapsed Time: %s", common.DurationDisplayString(elapsedTime))
+}
+
 func (c *MissionCard) updateContent(g *Game) {
 	switch c.style {
 	case MissionCardGame:
+		c.elapsedTimeText.Label = missionElapsedTime(g)
 		c.objectivesText.SetText(g.objectives.Text())
+	case MissionCardDebrief:
+		c.elapsedTimeText.Label = missionElapsedTime(g)
 	}
 }
 

--- a/game/mission.go
+++ b/game/mission.go
@@ -56,8 +56,11 @@ func (g *Game) initMission() {
 	g.player.cameraAngle = pHeading
 	g.player.cameraPitch = 0
 
-	// init player as powered off but booting up
-	g.player.SetPowered(model.POWER_ON)
+	// init player power status per mission configuration and then power on
+	g.player.SetInitialPoweredStatus(g.mission.DropZone.PowerStatus)
+	if g.player.Powered() != model.POWER_ON {
+		g.player.SetPowered(model.POWER_ON)
+	}
 
 	// init player armament for display
 	if armament := g.GetHUDElement(HUD_ARMAMENT); armament != nil {

--- a/game/model/emplacement.go
+++ b/game/model/emplacement.go
@@ -116,24 +116,6 @@ func (e *Emplacement) SetPowered(powered UnitPowerStatus) {
 }
 
 func (e *Emplacement) Update() bool {
-	isOverHeated := e.OverHeated()
-	if e.powered == POWER_ON {
-		// if heat is too high, auto shutdown
-		if isOverHeated {
-			e.SetPowered(POWER_OFF_HEAT)
-		}
-	} else {
-		switch {
-		case isOverHeated:
-			// continue cooling down
-			break
-
-		case e.powered == POWER_OFF_HEAT && !isOverHeated:
-			// set power on automatically after overheat status is cleared
-			e.SetPowered(POWER_ON)
-		}
-	}
-
 	if e.needsUpdate() {
 		e.UnitModel.update()
 	} else {

--- a/game/model/emplacement.go
+++ b/game/model/emplacement.go
@@ -33,7 +33,7 @@ func NewEmplacement(r *ModelEmplacementResource) *Emplacement {
 			maxVelocity:   0,
 			maxTurnRate:   EMPLACEMENT_TURRET_RATE_FACTOR,
 			maxTurretRate: EMPLACEMENT_TURRET_RATE_FACTOR,
-			powered:       POWER_ON, // TODO: define initial power status or power on event in mission resource
+			powered:       POWER_ON,
 		},
 	}
 
@@ -109,6 +109,10 @@ func (e *Emplacement) TriggerWeapon(w Weapon) bool {
 
 func (e *Emplacement) TurnRate() float64 {
 	return e.maxTurnRate
+}
+
+func (e *Emplacement) SetPowered(powered UnitPowerStatus) {
+	e.powered = powered
 }
 
 func (e *Emplacement) Update() bool {

--- a/game/model/infantry.go
+++ b/game/model/infantry.go
@@ -114,6 +114,10 @@ func (e *Infantry) TurnRate() float64 {
 	return e.maxTurnRate
 }
 
+func (e *Infantry) SetPowered(_ UnitPowerStatus) {
+	e.powered = POWER_ON
+}
+
 func (e *Infantry) Update() bool {
 	if e.needsUpdate() {
 		e.UnitModel.update()

--- a/game/model/infantry.go
+++ b/game/model/infantry.go
@@ -114,8 +114,8 @@ func (e *Infantry) TurnRate() float64 {
 	return e.maxTurnRate
 }
 
-func (e *Infantry) SetPowered(_ UnitPowerStatus) {
-	e.powered = POWER_ON
+func (e *Infantry) SetPowered(powered UnitPowerStatus) {
+	e.powered = powered
 }
 
 func (e *Infantry) Update() bool {

--- a/game/model/mech.go
+++ b/game/model/mech.go
@@ -59,7 +59,7 @@ func NewMech(r *ModelMechResource) *Mech {
 			maxTurretRate:      MECH_TURRET_RATE_FACTOR + (100 / r.Tonnage * MECH_TURRET_RATE_FACTOR),
 			jumpJets:           r.JumpJets,
 			maxJumpJetDuration: 1.0,
-			powered:            POWER_ON, // TODO: define initial power status or power on event in mission resource
+			powered:            POWER_ON,
 		},
 	}
 

--- a/game/model/mech.go
+++ b/game/model/mech.go
@@ -130,17 +130,19 @@ func (e *Mech) MaxStructurePoints() float64 {
 }
 
 func (e *Mech) SetPowered(powered UnitPowerStatus) {
-	if powered == POWER_ON {
-		if e.powered != POWER_ON && e.PowerOnTimer <= 0 {
+	switch powered {
+	case POWER_ON:
+		if e.powered != POWER_ON && e.powered != POWER_ON_IN_PROGRESS {
 			// initiate power up sequence
+			e.powered = POWER_ON_IN_PROGRESS
 			e.PowerOnTimer = int(MECH_POWER_ON_SECONDS * TICKS_PER_SECOND)
 		}
-	} else {
-		if e.powered == POWER_ON && e.PowerOffTimer <= 0 {
+	case POWER_OFF_MANUAL, POWER_OFF_HEAT:
+		if e.powered != POWER_OFF_MANUAL && e.powered != POWER_OFF_HEAT {
 			// initiate power down sequence
+			e.powered = powered
 			e.PowerOffTimer = int(UNIT_POWER_OFF_SECONDS * TICKS_PER_SECOND)
 		}
-		e.powered = powered
 	}
 }
 
@@ -162,7 +164,7 @@ func (e *Mech) Update() bool {
 			break
 
 		case e.powered == POWER_OFF_HEAT &&
-			!isOverHeated && e.PowerOnTimer == 0:
+			!isOverHeated && e.PowerOffTimer == 0:
 			// set power on sequence to begin automatically after overheat status is cleared
 			e.SetPowered(POWER_ON)
 

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -62,8 +62,9 @@ func (m *Mission) Map() *Map {
 }
 
 type DropZone struct {
-	Position [2]float64 `yaml:"position"`
-	Heading  float64    `yaml:"heading"`
+	Position    [2]float64      `yaml:"position"`
+	Heading     float64         `yaml:"heading"`
+	PowerStatus UnitPowerStatus `yaml:"powerStatus"`
 }
 
 type SpawnPoint struct {

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -129,6 +129,8 @@ type MissionUnit struct {
 	PatrolPath [][2]float64     `yaml:"patrolPath"`
 	GuardArea  MissionGuardArea `yaml:"guardArea"`
 	GuardUnit  string           `yaml:"guardUnit"`
+
+	PowerConditions UnitPowerConditions `yaml:"powerConditions"`
 }
 
 func (m MissionUnit) GetUnit() string {
@@ -153,6 +155,8 @@ type MissionFlyingUnit struct {
 	PatrolPath [][2]float64     `yaml:"patrolPath"`
 	GuardArea  MissionGuardArea `yaml:"guardArea"`
 	GuardUnit  string           `yaml:"guardUnit"`
+
+	PowerConditions UnitPowerConditions `yaml:"powerConditions"`
 }
 
 func (m MissionFlyingUnit) GetUnit() string {
@@ -248,6 +252,9 @@ func LoadMission(missionFile string) (*Mission, error) {
 		return nil, fmt.Errorf("[%s] %s", missionPath, err.Error())
 	}
 
+	// TODO: verify things that reference id/names of other things in the mission yaml, such as:
+	//       navPointVisited is defined as a navPoint name, and unitDestroyed defined as a unit id
+
 	// load mission map
 	err = m.loadMissionMap()
 	if err != nil {
@@ -278,7 +285,6 @@ func (m *Mission) loadMissionMap() error {
 	if m.missionMap.DropZone.Position == [2]float64{0, 0} {
 		// generate random dropzone when not provided
 		rngPos, rngHeading := randPlayerSpawnLocation(m.missionMap)
-		log.Debugf("rngPos: %v\n", rngPos)
 		m.DropZone = &DropZone{
 			Position:    [2]float64{rngPos.X, rngPos.Y},
 			Heading:     rngHeading,

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pixelmek-3d/pixelmek-3d/game/resources"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-youtils/stopwatch"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/harbdog/raycaster-go/geom"
 	"gopkg.in/yaml.v3"
@@ -16,6 +17,7 @@ import (
 
 type Mission struct {
 	missionMap   *Map
+	missionTimer *stopwatch.Stopwatch
 	Title        string              `yaml:"title" validate:"required"`
 	Briefing     string              `yaml:"briefing" validate:"required"`
 	MapPath      string              `yaml:"map" validate:"required"`
@@ -40,7 +42,8 @@ type Mission struct {
 }
 
 func NewMissionFromMapPath(mapPath string) (*Mission, error) {
-	m := &Mission{MapPath: mapPath}
+	m := newMission()
+	m.MapPath = mapPath
 	err := m.loadMissionMap()
 	if err != nil {
 		return nil, err
@@ -49,7 +52,8 @@ func NewMissionFromMapPath(mapPath string) (*Mission, error) {
 }
 
 func NewMissionFromMap(missionMap *Map) (*Mission, error) {
-	m := &Mission{missionMap: missionMap}
+	m := newMission()
+	m.missionMap = missionMap
 	err := m.loadMissionMap()
 	if err != nil {
 		return nil, err
@@ -57,8 +61,26 @@ func NewMissionFromMap(missionMap *Map) (*Mission, error) {
 	return m, nil
 }
 
+func newMission() *Mission {
+	m := &Mission{}
+	m.missionTimer = stopwatch.NewStopwatch()
+	return m
+}
+
 func (m *Mission) Map() *Map {
 	return m.missionMap
+}
+
+func (m *Mission) TimerPause() {
+	m.missionTimer.Stop()
+}
+
+func (m *Mission) TimerStart() {
+	m.missionTimer.Start()
+}
+
+func (m *Mission) TimerSeconds() float64 {
+	return m.missionTimer.Seconds()
 }
 
 type DropZone struct {
@@ -241,7 +263,7 @@ func LoadMission(missionFile string) (*Mission, error) {
 		return nil, err
 	}
 
-	m := &Mission{}
+	m := newMission()
 	err = yaml.Unmarshal(missionYaml, m)
 	if err != nil {
 		return nil, err

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -304,16 +304,18 @@ func (m *Mission) loadMissionMap() error {
 		m.MusicPath = m.missionMap.MusicPath
 	}
 
-	if m.missionMap.DropZone.Position == [2]float64{0, 0} {
-		// generate random dropzone when not provided
-		rngPos, rngHeading := randPlayerSpawnLocation(m.missionMap)
-		m.DropZone = &DropZone{
-			Position:    [2]float64{rngPos.X, rngPos.Y},
-			Heading:     rngHeading,
-			PowerStatus: POWER_OFF_MANUAL,
+	if m.DropZone == nil {
+		if m.missionMap.DropZone.Position == [2]float64{0, 0} {
+			// generate random dropzone when not provided
+			rngPos, rngHeading := randPlayerSpawnLocation(m.missionMap)
+			m.DropZone = &DropZone{
+				Position:    [2]float64{rngPos.X, rngPos.Y},
+				Heading:     rngHeading,
+				PowerStatus: POWER_OFF_MANUAL,
+			}
+		} else {
+			m.DropZone = &m.missionMap.DropZone
 		}
-	} else {
-		m.DropZone = &m.missionMap.DropZone
 	}
 
 	// apply optional overrides to map

--- a/game/model/mission.go
+++ b/game/model/mission.go
@@ -271,11 +271,21 @@ func (m *Mission) loadMissionMap() error {
 	m.Pathing = initPathing(m)
 
 	// apply any defaults from map
-	if m.DropZone == nil {
-		m.DropZone = &m.missionMap.DropZone
-	}
 	if m.MusicPath == "" && m.missionMap.MusicPath != "" {
 		m.MusicPath = m.missionMap.MusicPath
+	}
+
+	if m.missionMap.DropZone.Position == [2]float64{0, 0} {
+		// generate random dropzone when not provided
+		rngPos, rngHeading := randPlayerSpawnLocation(m.missionMap)
+		log.Debugf("rngPos: %v\n", rngPos)
+		m.DropZone = &DropZone{
+			Position:    [2]float64{rngPos.X, rngPos.Y},
+			Heading:     rngHeading,
+			PowerStatus: POWER_OFF_MANUAL,
+		}
+	} else {
+		m.DropZone = &m.missionMap.DropZone
 	}
 
 	// apply optional overrides to map
@@ -289,6 +299,33 @@ func (m *Mission) loadMissionMap() error {
 		m.missionMap.SkyBox = *m.SkyBox
 	}
 	return nil
+}
+
+func randPlayerSpawnLocation(missionMap *Map) (geom.Vector2, float64) {
+	// generate random spawn point and heading outside some min distance from edge of map
+	rng := NewRNG()
+	rH := rng.RandFloat64In(0, geom.Pi2)
+
+	// set some minimium offset distance from edge of map, taking into account very small maps
+	w, h := missionMap.Size()
+	offX, offY := 25, 25
+	if offX > w/4 {
+		offX = w / 4
+	}
+	if offY > h/4 {
+		offY = h / 4
+	}
+	minX, maxX := offX, w-offX
+	minY, maxY := offY, h-offY
+
+	rX := rng.RandIntIn(minX, maxX)
+	rY := rng.RandIntIn(minY, maxY)
+	for missionMap.IsWallAt(0, rX, rY) {
+		// location is in a wall, re-roll
+		rX = rng.RandIntIn(minX, maxX)
+		rY = rng.RandIntIn(minY, maxY)
+	}
+	return geom.Vector2{X: float64(rX) + 0.5, Y: float64(rY) + 0.5}, rH
 }
 
 func ListMissionFilenames() ([]string, error) {

--- a/game/model/rand.go
+++ b/game/model/rand.go
@@ -25,6 +25,10 @@ func (rng *Rand) RandFloat64In(lo, hi float64) float64 {
 	return RandFloat64In(lo, hi, rng.Rand)
 }
 
+func (rng *Rand) RandIntIn(lo, hi int) int {
+	return RandIntIn(lo, hi, rng.Rand)
+}
+
 func RandFloat64In(lo, hi float64, rng *rand.Rand) float64 {
 	var randFloat float64
 	if rng == nil {
@@ -33,6 +37,16 @@ func RandFloat64In(lo, hi float64, rng *rand.Rand) float64 {
 		randFloat = rng.Float64()
 	}
 	return lo + (hi-lo)*randFloat
+}
+
+func RandIntIn(lo, hi int, rng *rand.Rand) int {
+	var randFloat float64
+	if rng == nil {
+		randFloat = rand.Float64()
+	} else {
+		randFloat = rng.Float64()
+	}
+	return int(float64(lo) + float64(hi-lo)*randFloat)
 }
 
 func RandomMapKey[K comparable, V any](m map[K]V) K {

--- a/game/model/unit.go
+++ b/game/model/unit.go
@@ -66,6 +66,7 @@ type Unit interface {
 	OverHeated() bool
 	Powered() UnitPowerStatus
 	SetPowered(UnitPowerStatus)
+	SetInitialPoweredStatus(UnitPowerStatus)
 
 	TriggerWeapon(Weapon) bool
 	Target() Entity
@@ -309,7 +310,7 @@ func (e *UnitModel) Powered() UnitPowerStatus {
 	return e.powered
 }
 
-func (e *UnitModel) SetPowered(powered UnitPowerStatus) {
+func (e *UnitModel) SetInitialPoweredStatus(powered UnitPowerStatus) {
 	e.powered = powered
 }
 

--- a/game/model/unit.go
+++ b/game/model/unit.go
@@ -338,9 +338,11 @@ func (e *UnitModel) SetPowerConditions(powerConditions UnitPowerConditions) {
 		len(cpConditions.NavPointVisited) == 0 && len(cpConditions.MissionUnitDestroyed) == 0 {
 		// unset power conditions if there are none to set
 		e.powerConditions = nil
+		e.SetInitialPoweredStatus(POWER_ON)
 		return
 	}
 	e.powerConditions = &cpConditions
+	e.SetInitialPoweredStatus(POWER_OFF_MANUAL)
 }
 
 func (e *UnitModel) TriggerWeapon(w Weapon) bool {

--- a/game/model/unit.go
+++ b/game/model/unit.go
@@ -43,9 +43,10 @@ const (
 type UnitPowerStatus int
 
 const (
-	POWER_ON         UnitPowerStatus = 1
-	POWER_OFF_MANUAL UnitPowerStatus = 0
-	POWER_OFF_HEAT   UnitPowerStatus = -1
+	POWER_ON             UnitPowerStatus = 1
+	POWER_ON_IN_PROGRESS UnitPowerStatus = 2
+	POWER_OFF_MANUAL     UnitPowerStatus = 0
+	POWER_OFF_HEAT       UnitPowerStatus = -1
 )
 
 // UnitPowerConditions defines optional conditions for when unit powers on instead of mission start

--- a/game/model/unit.go
+++ b/game/model/unit.go
@@ -48,6 +48,18 @@ const (
 	POWER_OFF_HEAT   UnitPowerStatus = -1
 )
 
+// UnitPowerConditions defines optional conditions for when unit powers on instead of mission start
+type UnitPowerConditions struct {
+	// MissionTimeElapsed is the number of seconds since the mission started to trigger power on
+	MissionTimeElapsed int `yaml:"timeElapsed"`
+	// PlayerDistance is the distance from the player to trigger power on
+	PlayerDistance int `yaml:"playerDistance"`
+	// NavPointVisited is the name of the Nav Point the player just visited to trigger power on
+	NavPointVisited string `yaml:"navPointVisited"`
+	// MissionUnitDestroyed is the ID of the Unit whose destruction triggers power on
+	MissionUnitDestroyed string `yaml:"unitDestroyed"`
+}
+
 type Unit interface {
 	Entity
 	ID() string
@@ -67,6 +79,8 @@ type Unit interface {
 	Powered() UnitPowerStatus
 	SetPowered(UnitPowerStatus)
 	SetInitialPoweredStatus(UnitPowerStatus)
+	PowerConditions() *UnitPowerConditions
+	SetPowerConditions(UnitPowerConditions)
 
 	TriggerWeapon(Weapon) bool
 	Target() Entity
@@ -166,6 +180,7 @@ type UnitModel struct {
 	heatSinks           int
 	heatSinkType        HeatSinkType
 	powered             UnitPowerStatus
+	powerConditions     *UnitPowerConditions
 	armament            []Weapon
 	ammunition          *Ammo
 	jumpJets            int
@@ -312,6 +327,20 @@ func (e *UnitModel) Powered() UnitPowerStatus {
 
 func (e *UnitModel) SetInitialPoweredStatus(powered UnitPowerStatus) {
 	e.powered = powered
+}
+
+func (e *UnitModel) PowerConditions() *UnitPowerConditions {
+	return e.powerConditions
+}
+func (e *UnitModel) SetPowerConditions(powerConditions UnitPowerConditions) {
+	cpConditions := powerConditions
+	if cpConditions.MissionTimeElapsed == 0 && cpConditions.PlayerDistance == 0 &&
+		len(cpConditions.NavPointVisited) == 0 && len(cpConditions.MissionUnitDestroyed) == 0 {
+		// unset power conditions if there are none to set
+		e.powerConditions = nil
+		return
+	}
+	e.powerConditions = &cpConditions
 }
 
 func (e *UnitModel) TriggerWeapon(w Weapon) bool {

--- a/game/model/vehicle.go
+++ b/game/model/vehicle.go
@@ -39,7 +39,7 @@ func NewVehicle(r *ModelVehicleResource) *Vehicle {
 			maxTurnRate:     VEHICLE_TURN_RATE_FACTOR + (100 / r.Tonnage * VEHICLE_TURN_RATE_FACTOR),
 			maxTurretRate:   VEHICLE_TURRET_RATE_FACTOR + (100 / r.Tonnage * VEHICLE_TURRET_RATE_FACTOR),
 			jumpJets:        0,
-			powered:         POWER_ON, // TODO: define initial power status or power on event in mission resource
+			powered:         POWER_ON,
 		},
 	}
 
@@ -98,6 +98,10 @@ func (e *Vehicle) MaxArmorPoints() float64 {
 
 func (e *Vehicle) MaxStructurePoints() float64 {
 	return e.Resource.Structure
+}
+
+func (e *Vehicle) SetPowered(powered UnitPowerStatus) {
+	e.powered = powered
 }
 
 func (e *Vehicle) Update() bool {

--- a/game/model/vtol.go
+++ b/game/model/vtol.go
@@ -36,7 +36,7 @@ func NewVTOL(r *ModelVTOLResource) *VTOL {
 			maxTurnRate:   VTOL_TURN_RATE_FACTOR + (100 / r.Tonnage * VTOL_TURN_RATE_FACTOR),
 			maxTurretRate: VTOL_TURN_RATE_FACTOR + (100 / r.Tonnage * VTOL_TURN_RATE_FACTOR),
 			jumpJets:      0,
-			powered:       POWER_ON, // TODO: define initial power status or power on event in mission resource
+			powered:       POWER_ON,
 		},
 	}
 
@@ -106,6 +106,10 @@ func (e *VTOL) SetTargetVelocityZ(tVelocityZ float64) {
 		tVelocityZ = -maxV / 2
 	}
 	e.UnitModel.SetTargetVelocityZ(tVelocityZ)
+}
+
+func (e *VTOL) SetPowered(powered UnitPowerStatus) {
+	e.powered = powered
 }
 
 func (e *VTOL) Update() bool {

--- a/game/render/colors/colors.go
+++ b/game/render/colors/colors.go
@@ -3,6 +3,8 @@ package colors
 import "image/color"
 
 var (
+	Black         = color.NRGBA{R: 0, G: 0, B: 0, A: 255}
+	White         = color.NRGBA{R: 255, G: 255, B: 255, A: 255}
 	DefaultRed    = color.NRGBA{R: 225, G: 0, B: 0, A: 255}
 	DefaultGreen  = color.NRGBA{R: 0, G: 214, B: 0, A: 255}
 	DefaultBlue   = color.NRGBA{R: 0, G: 0, B: 203, A: 255}

--- a/game/render/compass.go
+++ b/game/render/compass.go
@@ -191,7 +191,7 @@ func (c *Compass) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
 				iRatio := float32(i) / float32(maxTurretDeg)
 				iX := float32(bX) + float32(bW)/2 + iRatio*float32(bW)/2
 
-				vector.DrawFilledCircle(screen, iX-iRadius, topY-iRadius, iRadius, iColor, false)
+				vector.FillCircle(screen, iX-iRadius, topY-iRadius, iRadius, iColor, false)
 				iRendered = true
 				break
 			}
@@ -211,7 +211,7 @@ func (c *Compass) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
 
 			iRadius := float32(bH) / 12
 			iX := float32(bX) + float32(bW)/2 + iRatio*float32(bW)/2
-			vector.DrawFilledCircle(screen, iX-iRadius, topY-iRadius, iRadius, iColor, false)
+			vector.FillCircle(screen, iX-iRadius, topY-iRadius, iRadius, iColor, false)
 		}
 	}
 

--- a/game/render/missionimage/image.go
+++ b/game/render/missionimage/image.go
@@ -193,7 +193,7 @@ func renderMissionUnit[T model.AnyUnitModel](m *missionImage, missionUnit model.
 	}
 
 	uX, uY := float32(u.Pos().X), float32(u.Pos().Y)
-	vector.DrawFilledCircle(m.image, uX*float32(pxPerCell), (float32(mapHeight)-uY)*float32(pxPerCell), float32(pxPerCell)/2, uColor, false)
+	vector.FillCircle(m.image, uX*float32(pxPerCell), (float32(mapHeight)-uY)*float32(pxPerCell), float32(pxPerCell)/2, uColor, false)
 
 	// render scaled unit image only if pxPerCell is high enough for detail
 	if pxPerCell >= 16 {

--- a/game/render/radar.go
+++ b/game/render/radar.go
@@ -11,8 +11,13 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/vector"
 	"github.com/harbdog/raycaster-go/geom"
 	"github.com/pixelmek-3d/pixelmek-3d/game/model"
+	"github.com/pixelmek-3d/pixelmek-3d/game/render/colors"
 	"github.com/pixelmek-3d/pixelmek-3d/game/render/fonts"
 	"github.com/tinne26/etxt"
+)
+
+const (
+	radarPingLifespan = int(1.0 * model.TICKS_PER_SECOND)
 )
 
 var (
@@ -27,6 +32,7 @@ type Radar struct {
 	fontRenderer *etxt.Renderer
 	mapLines     []*geom.Line
 	radarBlips   []*RadarBlip
+	radarPings   []*RadarPing
 	navPoints    []*RadarNavPoint
 	navLines     []*geom.Line
 	position     *geom.Vector2
@@ -37,6 +43,7 @@ type Radar struct {
 	showPosition bool
 }
 
+// RadarBlip represents persistent, targettable contacts on the radar
 type RadarBlip struct {
 	Unit          model.Unit
 	Angle         float64
@@ -45,6 +52,14 @@ type RadarBlip struct {
 	Distance      float64
 	IsTarget      bool
 	IsFriendly    bool
+}
+
+// RadarPing represents transient, unknown and untargettable contacts on the radar
+type RadarPing struct {
+	Entity   model.Entity
+	Angle    float64
+	Distance float64
+	ticks    int
 }
 
 type RadarNavPoint struct {
@@ -67,6 +82,7 @@ func NewRadar(font *fonts.Font) *Radar {
 		HUDSprite:    NewHUDSprite(nil, 1.0),
 		fontRenderer: renderer,
 		radarRange:   radarRanges[0] / model.METERS_PER_UNIT,
+		radarPings:   make([]*RadarPing, 0, 16),
 	}
 
 	return r
@@ -130,6 +146,16 @@ func (r *Radar) SetRadarBlips(blips []*RadarBlip) {
 	r.radarBlips = blips
 }
 
+func (r *Radar) AddRadarPing(ping *RadarPing) {
+	// make sure the entity doesn't already have an active ping
+	for _, rPing := range r.radarPings {
+		if ping.Entity == rPing.Entity {
+			return
+		}
+	}
+	r.radarPings = append(r.radarPings, ping)
+}
+
 func (r *Radar) SetValues(position *geom.Vector2, heading, turretAngle, fovDegrees float64) {
 	r.position = position
 	r.heading = heading
@@ -139,6 +165,34 @@ func (r *Radar) SetValues(position *geom.Vector2, heading, turretAngle, fovDegre
 
 func (r *Radar) ShowPosition(show bool) {
 	r.showPosition = show
+}
+
+func (r *Radar) Update() {
+	// Manage animated radar pings
+	numPings := len(r.radarPings)
+	if numPings > 0 {
+		stalePings := make([]int, 0, numPings)
+		for i, ping := range r.radarPings {
+			if ping.ticks < radarPingLifespan {
+				ping.ticks += 1
+				continue
+			}
+			// remove stale pings beyond their lifespan
+			stalePings = append(stalePings, i)
+		}
+		if len(stalePings) > 0 {
+			if numPings == len(stalePings) {
+				r.radarPings = make([]*RadarPing, 0, cap(r.radarPings))
+			} else {
+				// remove the stale pings
+				keepPings := r.radarPings[:]
+				for _, index := range slices.Backward(stalePings) {
+					keepPings = append(keepPings[:index], keepPings[index+1:]...)
+				}
+				r.radarPings = keepPings
+			}
+		}
+	}
 }
 
 func (r *Radar) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
@@ -211,10 +265,7 @@ func (r *Radar) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
 	nColor := hudOpts.HudColor(_colorRadarOutline)
 
 	for _, nav := range r.navPoints {
-		// convert heading angle into relative radar angle where "up" is forward
-		radarAngle := nav.Angle - geom.HalfPi
-
-		radarDistancePx := nav.Distance * radarHudSizeFactor
+		radarAngle, radarDistancePx := radarRelativeLocation(nav.Angle, nav.Distance, radarHudSizeFactor)
 		nLine := geom.LineFromAngle(midX, midY, radarAngle, radarDistancePx)
 
 		if nav.IsTarget {
@@ -236,15 +287,24 @@ func (r *Radar) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
 		vector.FillCircle(screen, float32(nLine.X2), float32(nLine.Y2), navRadius, nColor, false) // TODO: calculate thickness based on image size
 	}
 
+	// Draw animated radar pings
+	for _, ping := range r.radarPings {
+		radarAngle, radarDistancePx := radarRelativeLocation(ping.Angle, ping.Distance, radarHudSizeFactor)
+		pLine := geom.LineFromAngle(midX, midY, radarAngle, radarDistancePx)
+
+		pColor := hudOpts.HudColor(colors.White)
+
+		// animate by expanding radius over tick time the ping is active
+		var pRadius float32 = 1 + float32(ping.ticks)/10
+		vector.StrokeCircle(screen, float32(pLine.X2)-2, float32(pLine.Y2-2), pRadius, 1, pColor, false)
+	}
+
 	// Draw radar blips
 	eColor := hudOpts.HudColor(_colorEnemy)
 	fColor := hudOpts.HudColor(_colorFriendly)
 
 	for _, blip := range r.radarBlips {
-		// convert direction angle into relative radar angle where "up" is forward
-		radarAngle := blip.Angle - geom.HalfPi
-
-		radarDistancePx := blip.Distance * radarHudSizeFactor
+		radarAngle, radarDistancePx := radarRelativeLocation(blip.Angle, blip.Distance, radarHudSizeFactor)
 		bLine := geom.LineFromAngle(midX, midY, radarAngle, radarDistancePx)
 
 		var bColor color.NRGBA
@@ -369,4 +429,11 @@ func (r *Radar) drawRadarLine(dst *ebiten.Image, line *geom.Line, centerX, cente
 	rLine2 := geom.LineFromAngle(centerX, centerY, angle2, dist2*hudSizeFactor)
 
 	vector.StrokeLine(dst, float32(rLine1.X2), float32(rLine1.Y2), float32(rLine2.X2), float32(rLine2.Y2), lineWidth, clr, false)
+}
+
+// radarRelativeLocation converts actual direction angle into relative radar angle where "up" is forward
+func radarRelativeLocation(actualAngle, actualDistance, radarHudSizeFactor float64) (float64, float64) {
+	radarAngle := actualAngle - geom.HalfPi
+	radarDistancePx := actualDistance * radarHudSizeFactor
+	return radarAngle, radarDistancePx
 }

--- a/game/render/radar.go
+++ b/game/render/radar.go
@@ -226,14 +226,14 @@ func (r *Radar) Draw(bounds image.Rectangle, hudOpts *DrawHudOptions) {
 			if nav.NavPoint.Visited() {
 				navTargetRadius = 4
 			}
-			vector.DrawFilledCircle(screen, float32(nLine.X2), float32(nLine.Y2), navTargetRadius, tColor, false) // TODO: calculate thickness based on image size
+			vector.FillCircle(screen, float32(nLine.X2), float32(nLine.Y2), navTargetRadius, tColor, false) // TODO: calculate thickness based on image size
 		}
 
 		var navRadius float32 = 3
 		if nav.NavPoint.Visited() {
 			navRadius = 1
 		}
-		vector.DrawFilledCircle(screen, float32(nLine.X2), float32(nLine.Y2), navRadius, nColor, false) // TODO: calculate thickness based on image size
+		vector.FillCircle(screen, float32(nLine.X2), float32(nLine.Y2), navRadius, nColor, false) // TODO: calculate thickness based on image size
 	}
 
 	// Draw radar blips

--- a/game/resources/maps/debug_land.yaml
+++ b/game/resources/maps/debug_land.yaml
@@ -4,13 +4,13 @@
 name: Debuglandia
 seed: 42
 music: "icy_wastes.mp3"
-dropZone:
-  position: [50, 50]
-  heading: 15
-spawnPoints:
-  - [57, 65]
-  - [25, 12]
-  - [12, 25]
+# dropZone:
+#   position: [50, 50]
+#   heading: 15
+# spawnPoints:
+#   - [57, 65]
+#   - [25, 12]
+#   - [12, 25]
 lighting:
   falloff: -100
   illumination: 500

--- a/game/resources/missions/debug.yaml
+++ b/game/resources/missions/debug.yaml
@@ -39,6 +39,7 @@ mechs:
     powerConditions:
       unitDestroyed: "destroy_me"
       navPointVisited: "Foo"
+      playerDistance: 500
 vehicles:
   - id: "do_not_hurt_me"
     team: -1

--- a/game/resources/missions/debug.yaml
+++ b/game/resources/missions/debug.yaml
@@ -33,13 +33,18 @@ mechs:
     position: [57, 65]
     powerConditions:
       timeElapsed: 10
+  - id: "destroy_me_2"
+    unit: "adder_b"
+    position: [80, 80]
+    powerConditions:
+      unitDestroyed: "destroy_me"
 vehicles:
   - id: "do_not_hurt_me"
     team: -1
     unit: "srm_carrier"
     position: [57, 55]
     powerConditions:
-      timeElapsed: 15
+      timeElapsed: 10
 vtols: []
 infantry: []
 emplacements: []

--- a/game/resources/missions/debug.yaml
+++ b/game/resources/missions/debug.yaml
@@ -31,11 +31,15 @@ mechs:
   - id: "destroy_me"
     unit: "fire_moth_prime"
     position: [57, 65]
+    powerConditions:
+      timeElapsed: 10
 vehicles:
   - id: "do_not_hurt_me"
     team: -1
     unit: "srm_carrier"
     position: [57, 55]
+    powerConditions:
+      timeElapsed: 15
 vtols: []
 infantry: []
 emplacements: []

--- a/game/resources/missions/debug.yaml
+++ b/game/resources/missions/debug.yaml
@@ -38,6 +38,7 @@ mechs:
     position: [80, 80]
     powerConditions:
       unitDestroyed: "destroy_me"
+      navPointVisited: "Foo"
 vehicles:
   - id: "do_not_hurt_me"
     team: -1

--- a/game/resources/missions/debug.yaml
+++ b/game/resources/missions/debug.yaml
@@ -8,6 +8,7 @@ music: "icy_wastes.mp3"
 dropZone:
   position: [40, 60]
   heading: 90
+  powerStatus: 0
 objectives:
   destroy:
     - unit: "destroy_me"

--- a/game/resources/missions/trial_day.yaml
+++ b/game/resources/missions/trial_day.yaml
@@ -7,6 +7,7 @@ map: "proving_grounds"
 dropZone:
   position: [31.5, 3.5]
   heading: 45
+  powerStatus: 1
 objectives:
   destroy:
     - all: true

--- a/game/resources/missions/trial_dusk.yaml
+++ b/game/resources/missions/trial_dusk.yaml
@@ -17,6 +17,7 @@ skyBox:
 dropZone:
   position: [50, 50]
   heading: 270
+  powerStatus: 1
 objectives:
   destroy:
     - all: true

--- a/game/resources/missions/trial_night.yaml
+++ b/game/resources/missions/trial_night.yaml
@@ -17,6 +17,7 @@ skyBox:
 dropZone:
   position: [60, 60]
   heading: 270
+  powerStatus: 0
 objectives:
   nav:
     visit:

--- a/game/scene_game.go
+++ b/game/scene_game.go
@@ -50,10 +50,12 @@ func NewGameScene(g *Game) Scene {
 		scene.benchmark = NewBenchmarkHandler()
 	}
 
+	g.mission.TimerStart()
 	return scene
 }
 
 func (g *Game) LeaveGame() {
+	g.paused = true
 	if gs, ok := g.scene.(*GameScene); ok && gs.benchmark != nil {
 		// close benchmark
 		gs.benchmark.Close()

--- a/game/scene_game.go
+++ b/game/scene_game.go
@@ -114,6 +114,9 @@ func (s *GameScene) Update() error {
 		// handle player camera movement
 		g.updatePlayerCamera(false)
 
+		// handle player HUD tick-based udpates
+		g.updateHUD()
+
 		if g.InProgress() {
 			if s.transition != nil {
 				// update transition at start of game

--- a/game/spawn.go
+++ b/game/spawn.go
@@ -10,6 +10,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func randEnemySpawnLocation(g *Game) geom.Vector2 {
+	// generate random spawn point within some min/max distance of player
+	rng := model.NewRNG()
+	missionMap := g.mission.Map()
+	w, h := missionMap.Size()
+
+	x, y := int(g.player.Pos().X), int(g.player.Pos().Y)
+	rX, rY := rng.RandRelativeLocation(x, y, 20, 40, w, h)
+	for missionMap.IsWallAt(0, rX, rY) {
+		// location is in a wall, re-roll
+		rX, rY = rng.RandRelativeLocation(x, y, 20, 40, w, h)
+	}
+	return geom.Vector2{X: float64(rX) + 0.5, Y: float64(rY) + 0.5}
+}
+
 func spawnUnit[T model.AnyUnitModel](g *Game, u model.Unit) *T {
 	unit := u.CloneUnit()
 	unit.SetInitialPoweredStatus(model.POWER_OFF_MANUAL)
@@ -17,26 +32,21 @@ func spawnUnit[T model.AnyUnitModel](g *Game, u model.Unit) *T {
 	missionMap := g.mission.Map()
 	rng := model.NewRNG()
 
-	var spawnPos [2]float64
+	var spawnPos geom.Vector2
 	switch len(missionMap.SpawnPoints) {
 	case 0:
-		// generate random spawn point within some min/max distance of player
-		w, h := missionMap.Size()
-		x, y := int(g.player.Pos().X), int(g.player.Pos().Y)
-		rX, rY := rng.RandRelativeLocation(x, y, 10, 20, w, h) // TODO: pick better min/max
-		for missionMap.IsWallAt(0, rX, rY) {
-			// location is in a wall, re-roll
-			rX, rY = rng.RandRelativeLocation(x, y, 10, 20, w, h) // TODO: pick better min/max
-		}
-		spawnPos = [2]float64{float64(rX) + 0.5, float64(rY) + 0.5}
+		// random spawn point within some distance of player
+		spawnPos = randEnemySpawnLocation(g)
 	case 1:
-		spawnPos = missionMap.SpawnPoints[0]
+		spawnPoint := missionMap.SpawnPoints[0]
+		spawnPos = geom.Vector2{X: spawnPoint[0], Y: spawnPoint[1]}
 	default:
 		// TODO: pick random spawn point that was not picked last time
-		spawnPos = missionMap.SpawnPoints[rng.Intn(len(missionMap.SpawnPoints))]
+		spawnPoint := missionMap.SpawnPoints[rng.Intn(len(missionMap.SpawnPoints))]
+		spawnPos = geom.Vector2{X: spawnPoint[0], Y: spawnPoint[1]}
 	}
 
-	unit.SetPos(&geom.Vector2{X: spawnPos[0], Y: spawnPos[1]})
+	unit.SetPos(&spawnPos)
 
 	// attach AI to unit
 	g.ai.NewUnitAI(unit)

--- a/game/spawn.go
+++ b/game/spawn.go
@@ -12,6 +12,7 @@ import (
 
 func spawnUnit[T model.AnyUnitModel](g *Game, u model.Unit) *T {
 	unit := u.CloneUnit()
+	unit.SetInitialPoweredStatus(model.POWER_OFF_MANUAL)
 
 	missionMap := g.mission.Map()
 	rng := model.NewRNG()

--- a/game/sprites.go
+++ b/game/sprites.go
@@ -164,6 +164,36 @@ func (g *Game) getUnitSprites() []*sprites.Sprite {
 	return sprites
 }
 
+func (g *Game) getUnitSpriteByID(unitID string) *sprites.Sprite {
+	var sprite *sprites.Sprite
+	for _, spriteType := range g.sprites.SpriteTypes() {
+		g.sprites.RangeByType(spriteType, func(k, _ any) bool {
+			if !isInteractiveType(spriteType) {
+				// only include certain sprite types (skip projectiles, effects, etc.)
+				return true
+			}
+
+			s := getSpriteFromInterface(k.(raycaster.Sprite))
+			u := s.Unit()
+			if u != nil && u.ID() == unitID {
+				sprite = s
+				// break out of syncmap range loop
+				return false
+			}
+			return true
+		})
+	}
+	return sprite
+}
+
+func (g *Game) getSpriteUnitByID(unitID string) model.Unit {
+	uSprite := g.getUnitSpriteByID(unitID)
+	if uSprite != nil {
+		return uSprite.Unit()
+	}
+	return nil
+}
+
 func (g *Game) getSpriteUnits() []model.Unit {
 	uSprites := g.getUnitSprites()
 	units := make([]model.Unit, 0, len(uSprites))

--- a/game/update_sprites.go
+++ b/game/update_sprites.go
@@ -74,7 +74,7 @@ func (g *Game) updateSprite(spriteType sprites.SpriteType, sInterface raycaster.
 		g.updateWeaponCooldowns(sUnit)
 
 		if sUnit.Powered() != model.POWER_ON {
-			poweringOn := s.AnimationReversed()
+			poweringOn := sUnit.Powered() == model.POWER_ON_IN_PROGRESS
 			if mech.PowerOffTimer > 0 &&
 				(s.MechAnimation() != sprites.MECH_ANIMATE_SHUTDOWN || poweringOn) {
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/go-youtils/stopwatch v1.0.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-youtils/stopwatch v1.0.0 h1:4wiauq4dmXMkmshvPffZvhuUSPE+NZ+14cCzBBgMaHc=
+github.com/go-youtils/stopwatch v1.0.0/go.mod h1:vfgcMEfWg2GvLq+FI9MSVMaicsltKlc16FUM+f6JOSw=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
- define initial player powered status in mission configuration
- initialize instant action player and unit spawn powered status to off
- make shutdown units not targetable and not on radar unless close enough
- display radar "pings" when a unit is powering on before it becomes a "blip"